### PR TITLE
Stop the node process when done indexing

### DIFF
--- a/bin/record-crate.js
+++ b/bin/record-crate.js
@@ -31,6 +31,7 @@ var yargs = require('yargs')
           esUrl: args['es-url']
         })).index(function() {
           console.log(chalk.green("finished indexing '" + args['music-folder'] + "', run record-crate start."));
+          process.exit();
         });
       }
     },


### PR DESCRIPTION
I was confused when running `index`, because the message clearly told me to start another node process, but the node kept running.
Adding this small piece of code actually kills (with a success) the process.
